### PR TITLE
Fix null pointer when setmethod is null

### DIFF
--- a/MappingGenerator/MappingGenerator/MappingGenerator/MappingGenerator.cs
+++ b/MappingGenerator/MappingGenerator/MappingGenerator/MappingGenerator.cs
@@ -66,7 +66,8 @@ namespace MappingGenerator
             var localTargetIdentifier = targetExists? globbalTargetAccessor: generator.IdentifierName(targetLocalVariableName);
             foreach (var targetProperty in ObjectHelper.GetPublicPropertySymbols(targetType))
             {
-                if (targetProperty.SetMethod.DeclaredAccessibility != Accessibility.Public && globbalTargetAccessor.Kind() != SyntaxKind.ThisExpression)
+
+                if (targetProperty.SetMethod?.DeclaredAccessibility != Accessibility.Public && globbalTargetAccessor.Kind() != SyntaxKind.ThisExpression)
                 {
                     continue;
                 }


### PR DESCRIPTION
If a targetProperty didn't have a set it causes the extension to crash