### PR TITLE
Update netcoreapp3.1 and dependencies

### DIFF
--- a/MappingGenerator/MappingGenerator/MappingGenerator.Test/MappingGenerator.Test.csproj
+++ b/MappingGenerator/MappingGenerator/MappingGenerator.Test/MappingGenerator.Test.csproj
@@ -1,20 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNet.Identity.EntityFramework" Version="2.2.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.8.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.8.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="2.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.AspNet.Identity.EntityFramework" Version="2.2.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="3.5.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="SmartAnalyzers.RoslynTestKit" Version="3.0.61" />
   </ItemGroup>
 
@@ -108,5 +111,4 @@
       <LastGenOutput>UseLocalVariablesTestCases.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-
 </Project>

--- a/MappingGenerator/MappingGenerator/MappingGenerator/MappingGenerator.csproj
+++ b/MappingGenerator/MappingGenerator/MappingGenerator/MappingGenerator.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <PackageId>MappingGenerator</PackageId>
     <PackageVersion>2.0.0.0</PackageVersion>
@@ -24,12 +24,12 @@
     <Version>2.0.0</Version>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
-  
-   
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.8.2" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="2.0.0" PrivateAssets="all" />
-    <PackageReference Include="Pluralize.NET" Version="0.1.84" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="3.5.0" PrivateAssets="all" />
+    <PackageReference Include="Pluralize.NET" Version="1.0.2" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 
@@ -42,5 +42,4 @@
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="$(OutputPath)\Pluralize.NET.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
-
 </Project>

--- a/MappingGenerator/MappingGenerator/MappingGenerator/MappingGenerator.csproj
+++ b/MappingGenerator/MappingGenerator/MappingGenerator/MappingGenerator.csproj
@@ -26,7 +26,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.5.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="3.5.0" PrivateAssets="all" />
     <PackageReference Include="Pluralize.NET" Version="1.0.2" PrivateAssets="all" />

--- a/MappingGenerator/MappingGenerator/MappingGenerator/RoslynHelpers/SymbolHelper.cs
+++ b/MappingGenerator/MappingGenerator/MappingGenerator/RoslynHelpers/SymbolHelper.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace MappingGenerator.RoslynHelpers
 {
@@ -19,7 +19,7 @@ namespace MappingGenerator.RoslynHelpers
             {
                 return namedType.ConstraintTypes;
             }
-            return new []{typeSymbol};
+            return new[] { typeSymbol };
         }
 
         public static bool CanBeSetPrivately(this IPropertySymbol property)
@@ -29,14 +29,14 @@ namespace MappingGenerator.RoslynHelpers
             {
                 return false;
             }
-            return HasPrivateSetter(propertyDeclaration) || HasPublicSetter(propertyDeclaration, isInternalAccessible:true);
-        } 
-        
+            return HasPrivateSetter(propertyDeclaration) || HasPublicSetter(propertyDeclaration, isInternalAccessible: true);
+        }
+
         public static bool CanBeSetPublicly(this IPropertySymbol property, bool isInternalAccessible)
         {
             if (IsDeclaredOutsideTheSourcecode(property))
             {
-                return property.IsReadOnly == false && 
+                return property.IsReadOnly == false &&
                        property.SetMethod != null &&
                        property.SetMethod.DeclaredAccessibility == Accessibility.Public;
             }
@@ -56,10 +56,9 @@ namespace MappingGenerator.RoslynHelpers
             {
                 return property.IsReadOnly ||
                        (property.SetMethod != null &&
-                       new[] {Accessibility.Public, Accessibility.Protected}.Contains(property.SetMethod.DeclaredAccessibility)
+                       new[] { Accessibility.Public, Accessibility.Protected }.Contains(property.SetMethod.DeclaredAccessibility)
                        );
             }
-
 
             var propertyDeclaration = property.DeclaringSyntaxReferences.Select(x => x.GetSyntax()).OfType<PropertyDeclarationSyntax>().FirstOrDefault();
             if (propertyDeclaration?.AccessorList == null)
@@ -82,9 +81,9 @@ namespace MappingGenerator.RoslynHelpers
 
         private static bool HasPrivateSetter(PropertyDeclarationSyntax propertyDeclaration)
         {
-            return propertyDeclaration.AccessorList.Accessors.Any(x =>x.Keyword.Kind() == SyntaxKind.SetKeyword && x.Modifiers.Any(m => m.Kind() == SyntaxKind.PrivateKeyword));
-        } 
-        
+            return propertyDeclaration.AccessorList.Accessors.Any(x => x.Keyword.Kind() == SyntaxKind.SetKeyword && x.Modifiers.Any(m => m.Kind() == SyntaxKind.PrivateKeyword));
+        }
+
         private static bool HasPublicSetter(PropertyDeclarationSyntax propertyDeclaration, bool isInternalAccessible)
         {
             return propertyDeclaration.AccessorList.Accessors.Any(x =>
@@ -115,7 +114,7 @@ namespace MappingGenerator.RoslynHelpers
 
         private static bool IsAutoGetter(AccessorDeclarationSyntax x)
         {
-            return x.IsKind(SyntaxKind.GetAccessorDeclaration) && x.Body ==null && x.ExpressionBody == null;
+            return x.IsKind(SyntaxKind.GetAccessorDeclaration) && x.Body == null && x.ExpressionBody == null;
         }
 
         public static bool IsNullable(ITypeSymbol type, out ITypeSymbol underlyingType)
@@ -126,13 +125,19 @@ namespace MappingGenerator.RoslynHelpers
                 return true;
             }
 
+            if (type.NullableAnnotation == NullableAnnotation.Annotated)
+            {
+                underlyingType = type.OriginalDefinition;
+                return true;
+            }
+
             underlyingType = null;
             return false;
         }
 
         public static ITypeSymbol GetUnderlyingNullableType(ITypeSymbol type)
         {
-            return ((INamedTypeSymbol) type).TypeArguments.First();
+            return ((INamedTypeSymbol)type).TypeArguments.First();
         }
     }
 }

--- a/MappingGenerator/OnBuildGenerator/MappingGenerator.OnBuildGenerator.csproj
+++ b/MappingGenerator/OnBuildGenerator/MappingGenerator.OnBuildGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <Version>2.0.0.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
Since netcoreapp3.0 is EOL, this pull requests updates the projects to netcoreapp3.1 (LTS)

- [x] Update projects to netcoreapp3.1 and netstandard 2.0
- [ ] Update SmartCodeGenerator.Sdk version after https://github.com/cezarypiatek/SmartCodeGenerator/pull/6 is merged.
- [ ] Should the extension project dependencies also be updated?